### PR TITLE
Handle missing api_secret error

### DIFF
--- a/server/config/cloudinary.js
+++ b/server/config/cloudinary.js
@@ -5,7 +5,7 @@ const connectCloudinary = async () => {
     cloudinary.config({
         cloud_name: process.env.CLOUDINARY_NAME,
         api_key: process.env.CLOUDINARY_API_KEY,
-        api_secret_key: process.env.CLOUDINARY_SECRET_KEY
+        api_secret: process.env.CLOUDINARY_SECRET_KEY
     })
 
 }

--- a/server/controllers/companyController.js
+++ b/server/controllers/companyController.js
@@ -1,4 +1,5 @@
 import Company from "../models/Company.js";
+import Job from "../models/Job.js";
 import bcrypt from "bcrypt";
 import {v2 as cloudinary} from 'cloudinary';
 import generateToken from "../utils/generateToken.js";
@@ -61,7 +62,48 @@ export const getCompanyData = async (req,resp) =>{
 
 //post a new job
 export const postJob = async (req,resp) =>{
-
+    const { title, description, salary, location, category, level } = req.body;
+    
+    // Validate required fields
+    if (!title || !description || !salary || !location || !category || !level) {
+        return resp.json({
+            success: false,
+            message: "Missing Details"
+        });
+    }
+    
+    try {
+        // Create new job
+        const job = await Job.create({
+            title,
+            description,
+            salary,
+            location,
+            category,
+            level,
+            company: req.company._id
+        });
+        
+        resp.json({
+            success: true,
+            message: "Job posted successfully",
+            job: {
+                _id: job._id,
+                title: job.title,
+                description: job.description,
+                salary: job.salary,
+                location: job.location,
+                category: job.category,
+                level: job.level,
+                date: job.date
+            }
+        });
+    } catch (error) {
+        resp.json({
+            success: false,
+            message: error.message
+        });
+    }
 }
 
 //get company job Application

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -1,0 +1,41 @@
+import jwt from 'jsonwebtoken';
+import Company from '../models/Company.js';
+
+const authMiddleware = async (req, res, next) => {
+    try {
+        // Get token from header
+        const token = req.header('Authorization')?.replace('Bearer ', '') || req.header('token');
+        
+        if (!token) {
+            return res.json({
+                success: false,
+                message: "Not Authorised, login again"
+            });
+        }
+
+        // Verify token
+        const decoded = jwt.verify(token, process.env.JWT_SECRET);
+        
+        // Find the company
+        const company = await Company.findById(decoded.id);
+        
+        if (!company) {
+            return res.json({
+                success: false,
+                message: "Not Authorised, login again"
+            });
+        }
+
+        // Add company to request object
+        req.company = company;
+        next();
+    } catch (error) {
+        console.error('Auth middleware error:', error);
+        return res.json({
+            success: false,
+            message: "Not Authorised, login again"
+        });
+    }
+};
+
+export default authMiddleware;

--- a/server/models/Job.js
+++ b/server/models/Job.js
@@ -1,0 +1,45 @@
+import mongoose from "mongoose";
+
+const jobSchema = new mongoose.Schema({
+    title: {
+        type: String,
+        required: true
+    },
+    description: {
+        type: String,
+        required: true
+    },
+    salary: {
+        type: Number,
+        required: true
+    },
+    location: {
+        type: String,
+        required: true
+    },
+    category: {
+        type: String,
+        required: true
+    },
+    level: {
+        type: String,
+        required: true
+    },
+    company: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Company',
+        required: true
+    },
+    date: {
+        type: Date,
+        default: Date.now
+    },
+    visible: {
+        type: Boolean,
+        default: true
+    }
+});
+
+const Job = mongoose.model("Job", jobSchema);
+
+export default Job;

--- a/server/routes/companyRoutes.js
+++ b/server/routes/companyRoutes.js
@@ -1,6 +1,7 @@
 import express from "express";
 import { changeJobApplicationStatus, changeJobVisibility, getCompanyData, getCompanyJobApplication, getCompanyPostedJobs, loginCompany, postJob, registerCompany } from "../controllers/companyController.js";
 import upload from "../config/multer.js";
+import authMiddleware from "../middleware/authMiddleware.js";
 
 const router = express.Router();
 
@@ -14,7 +15,7 @@ router.post("/comapny",loginCompany)
 router.get("/company",getCompanyData)
 
 //post a job
-router.post("/post-job",postJob)
+router.post("/post-job", authMiddleware, postJob)
 
 //get Applicant data of company
 router.get("/application",getCompanyJobApplication)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix API secret validation and implement job posting with authentication.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR resolves the "Must supply api_secret" error by correcting the Cloudinary configuration property from `api_secret_key` to `api_secret`. It also addresses the "Not Authorised, login again" error by adding a new authentication middleware, defining a Job model, and implementing the `postJob` function, ensuring the job posting endpoint is properly secured and functional.